### PR TITLE
修复了不支持302跳转浏览器下，访问需验证模块会导致panic的问题。

### DIFF
--- a/src/rbac.go
+++ b/src/rbac.go
@@ -24,6 +24,7 @@ func AccessRegister() {
 				uinfo := ctx.Input.Session("userinfo")
 				if uinfo == nil {
 					ctx.Redirect(302, rbac_auth_gateway)
+                    return
 				}
 				//admin用户不用认证权限
 				adminuser := beego.AppConfig.String("rbac_admin_user")


### PR DESCRIPTION
	modified:   src/rbac.go

                if uinfo == nil {
                    ctx.Redirect(302, rbac_auth_gateway)
                    return
                }
                //admin用户不用认证权限
                adminuser := beego.AppConfig.String("rbac_admin_user")
                if uinfo.(m.User).Username == adminuser {
                    return
                }

如果浏览器不支持302跳转，那么uinfo 这个 nil 就会往下执行，然后panic。