### PR TITLE
修复了无法对带参数get请求正确判断权限的bug

### DIFF
--- a/src/rbac.go
+++ b/src/rbac.go
@@ -19,7 +19,7 @@ func AccessRegister() {
 		rbac_auth_gateway := beego.AppConfig.String("rbac_auth_gateway")
 		var accesslist map[string]bool
 		if user_auth_type > 0 {
-			params := strings.Split(strings.ToLower(ctx.Request.RequestURI), "/")
+			params := strings.Split(strings.ToLower(strings.Split(ctx.Request.RequestURI, "?")[0]), "/")
 			if CheckAccess(params) {
 				uinfo := ctx.Input.Session("userinfo")
 				if uinfo == nil {


### PR DESCRIPTION
beego 的 ctx.Request.RequestURI 参数包含了 get 请求的参数。
而源代码在做权限判断 params[2] 中 并没有过滤掉 get 传参(www.example.com/package/controller/method?param) 的 param 部分。
所以method 权限会以 method?param 进行匹配， 无法匹配权限。